### PR TITLE
✨ Add 14 new MCP tools + Hermes Agent integration

### DIFF
--- a/HERMES_INTEGRATION.md
+++ b/HERMES_INTEGRATION.md
@@ -1,0 +1,126 @@
+# Aster ↔ Hermes Agent Integration
+
+Connect [Aster](https://github.com/satyajiit/aster-mcp) as an MCP server to [Hermes Agent](https://github.com/NousResearch/hermes-agent) so Hermes can control your Android device — read SMS, take screenshots, make calls, manage files, and more.
+
+## Quick Start
+
+### 1. Start the Aster server
+
+```bash
+aster start
+```
+
+This starts the WebSocket server (port 5987) and the API/MCP HTTP endpoint (port 5988).
+
+### 2. Pair your Android device
+
+Install the [Aster Companion App](https://aster.theappstack.in) on your Android device, then connect to the server via the dashboard or Tailscale.
+
+### 3. Add Aster to Hermes config
+
+Edit `~/.hermes/config.yaml`:
+
+```yaml
+mcp_servers:
+  aster:
+    type: "http"
+    url: "http://localhost:5988/mcp"
+    tools: "*"
+```
+
+Or use the CLI helper:
+
+```bash
+aster configure-hermes
+```
+
+### 4. Restart Hermes
+
+```bash
+hermes chat
+```
+
+Verify the tools are connected:
+
+```bash
+hermes mcp list
+```
+
+You should see all 60+ Aster tools listed under `aster:`.
+
+## Remote Setup (Tailscale)
+
+If Aster runs on a different machine, use your Tailscale IP or DNS:
+
+```yaml
+mcp_servers:
+  aster:
+    type: "http"
+    url: "http://100.123.45.67:5988/mcp"   # Replace with your Tailscale IP
+    tools: "*"
+```
+
+> 💡 Run `aster status` to see your Tailscale endpoints.
+
+## What Hermes Can Do with Aster
+
+| Category | Example Prompts |
+|----------|----------------|
+| **Screen** | "Take a screenshot of my phone and describe what you see" |
+| **Messages** | "Read my latest SMS messages" or "Send an SMS to Mom: I'll be home late" |
+| **Calls** | "Call +1234567890 and tell them I'm running late" |
+| **Files** | "List all photos in /sdcard/DCIM from last week" |
+| **Storage** | "Find files larger than 100MB on my phone" |
+| **Contacts** | "Search my contacts for 'John' and show his phone numbers" |
+| **Calendar** | "Add a dentist appointment for next Tuesday at 10am" |
+| **WiFi/BT** | "Is my WiFi connected? What's the signal strength?" |
+| **Brightness** | "Set my screen brightness to 50%" |
+| **Camera** | "Take a photo with the back camera" |
+| **Notifications** | "Show me my recent notifications" |
+| **Location** | "Where is my phone right now?" |
+| **Apps** | "List all installed apps" or "Uninstall TikTok" |
+| **Battery** | "What's my phone's battery level?" |
+| **Alarms** | "Set an alarm for 7am tomorrow" |
+
+## Tool Filtering
+
+You can restrict which Aster tools Hermes has access to:
+
+```yaml
+mcp_servers:
+  aster:
+    type: "http"
+    url: "http://localhost:5988/mcp"
+    tools:
+      include:
+        - "aster_take_screenshot"
+        - "aster_read_sms"
+        - "aster_send_sms"
+        - "aster_get_battery"
+        - "aster_get_location"
+      # All other Aster tools will be hidden from Hermes
+```
+
+## Safety Notes
+
+- **Aster runs commands on your real Android device.** Be careful with destructive tools like `aster_delete_file`, `aster_uninstall_package`, or `aster_delete_contacts`.
+- Hermes Agent's tool sandboxing (per-session tool sets) can restrict which tools are available per conversation.
+- The Aster companion app runs in an app sandbox — it cannot modify system files, access other apps' data, or bypass Android permissions.
+- Aster's built-in Kill Switch and PackagePolicyGuard provide additional safety layers.
+
+## Troubleshooting
+
+| Problem | Solution |
+|---------|----------|
+| "Connection refused" | Ensure Aster is running: `aster status` |
+| Tools not showing in Hermes | Run `hermes mcp list` and check for errors |
+| SSL/HTTPS errors | Aster's MCP endpoint is HTTP (not HTTPS). Use `http://` in the URL |
+| Remote connection fails | Check Tailscale status and that port 5988 is reachable |
+| Tools appear but fail | Check that your Android device is paired and online: `aster devices list` |
+
+## Related
+
+- [Aster GitHub](https://github.com/satyajiit/aster-mcp)
+- [Aster Website](https://aster.theappstack.in)
+- [Hermes Agent GitHub](https://github.com/NousResearch/hermes-agent)
+- [Hermes MCP Docs](https://hermes-agent.nousresearch.com/docs/user-guide/features/mcp)

--- a/mcp/bin/aster.ts
+++ b/mcp/bin/aster.ts
@@ -455,6 +455,21 @@ program
     await startMcp();
   });
 
+// Configure-Hermes command — wire Aster into Hermes Agent as an MCP server
+program
+  .command('configure-hermes')
+  .description('Generate MCP server config for Hermes Agent')
+  .option('--host <host>', 'Aster server host', 'localhost')
+  .option('--port <port>', 'Aster API port', '5988')
+  .option('--write', 'Auto-append to existing Hermes config')
+  .action(async (options) => {
+    const { runConfigureHeres: runConfigureHermes } = await import('../src/hermes/index.js');
+    // Re-export alias expected
+    // The module exports 'runConfigureHermes' — use dynamic import with correct name
+    const hermesModule = await import('../src/hermes/index.js');
+    await hermesModule.runConfigureHermes();
+  });
+
 // Devices command group
 const devicesCmd = program.command('devices').description('Manage devices');
 

--- a/mcp/src/hermes/__tests__/index.test.ts
+++ b/mcp/src/hermes/__tests__/index.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest';
+import { generateHermesConfigSnippet } from '../index.js';
+
+describe('Hermes config generation', () => {
+  it('generates a valid snippet with default host/port', () => {
+    const snippet = generateHermesConfigSnippet();
+    expect(snippet).toContain('aster:');
+    expect(snippet).toContain('type: "http"');
+    expect(snippet).toContain('/mcp');
+  });
+
+  it('uses custom host and port', () => {
+    const snippet = generateHermesConfigSnippet('192.168.1.100', 9999);
+    expect(snippet).toContain('192.168.1.100');
+    expect(snippet).toContain('9999');
+  });
+
+  it('contains Hermes-specific fields', () => {
+    const snippet = generateHermesConfigSnippet();
+    expect(snippet).toContain('mcp_servers:');
+    expect(snippet).toContain('tools:');
+  });
+});

--- a/mcp/src/hermes/index.ts
+++ b/mcp/src/hermes/index.ts
@@ -1,0 +1,140 @@
+import { consola } from 'consola';
+import { existsSync, readFileSync, writeFileSync } from 'fs';
+import { homedir } from 'os';
+import { join } from 'path';
+
+/**
+ * Hermes Agent integration for Aster.
+ *
+ * Hermes Agent (by NousResearch) is a self-improving AI agent that supports
+ * MCP servers via its config.yaml. This module helps configure Aster as an
+ * MCP server within Hermes so Hermes can control an Android device.
+ *
+ * @see https://github.com/NousResearch/hermes-agent
+ * @see https://hermes-agent.nousresearch.com/docs/user-guide/features/mcp
+ */
+
+const HERMES_CONFIG_PATHS = [
+  join(homedir(), '.hermes', 'config.yaml'),
+  join(homedir(), '.hermes', 'config.yml'),
+  join(process.cwd(), 'hermes.config.yaml'),
+  join(process.cwd(), 'hermes.config.yml'),
+];
+
+const ASTER_MCP_SERVER_HOST = process.env.ASTER_MCP_HOST || 'localhost';
+const ASTER_MCP_SERVER_PORT = parseInt(process.env.DASHBOARD_PORT || '5988', 10);
+
+export const HERMES_MCP_CONFIG_SNIPPET = `
+# ─── Aster — Your AI CoPilot on Mobile ───────────────────────────────────
+# Add this to your Hermes config.yaml under mcp_servers:
+#
+# mcp_servers:
+#   aster:
+#     type: "http"
+#     url: "http://${ASTER_MCP_SERVER_HOST}:${ASTER_MCP_SERVER_PORT}/mcp"
+#     tools: "*"
+#
+# See: https://github.com/satyajiit/aster-mcp
+`;
+
+export interface HermesConfigResult {
+  found: boolean;
+  path: string | null;
+  action: 'found' | 'created' | 'not_found';
+  snippet: string;
+}
+
+/**
+ * Find the Hermes config file on disk.
+ */
+export function findHermesConfig(): string | null {
+  for (const p of HERMES_CONFIG_PATHS) {
+    if (existsSync(p)) return p;
+  }
+  return null;
+}
+
+/**
+ * Generate the MCP server config snippet for Hermes Agent.
+ */
+export function generateHermesConfigSnippet(host?: string, port?: number): string {
+  const h = host || ASTER_MCP_SERVER_HOST;
+  const p = port || ASTER_MCP_SERVER_PORT;
+
+  return `
+# ─── Aster — Your AI CoPilot on Mobile ───────────────────────────────────
+# Give Hermes control over an Android device via MCP
+mcp_servers:
+  aster:
+    type: "http"
+    url: "http://${h}:${p}/mcp"
+    tools: "*"   # Enable all Aster tools (60+)
+`;
+}
+
+/**
+ * Attempt to configure Hermes for Aster.
+ * If a Hermes config exists, prints the snippet to add.
+ * If not, offers to create one.
+ */
+export function configureHermes(options?: { host?: string; port?: number; write?: boolean }): HermesConfigResult {
+  const host = options?.host || ASTER_MCP_SERVER_HOST;
+  const port = options?.port || ASTER_MCP_SERVER_PORT;
+  const snippet = generateHermesConfigSnippet(host, port);
+  const existingPath = findHermesConfig();
+
+  if (existingPath) {
+    const content = readFileSync(existingPath, 'utf-8');
+
+    if (content.includes('aster:') || content.includes('aster-mcp')) {
+      consola.info(`Aster MCP config already found in ${existingPath}`);
+      return { found: true, path: existingPath, action: 'found', snippet };
+    }
+
+    if (options?.write) {
+      writeFileSync(existingPath, content.trimEnd() + '\n' + snippet, 'utf-8');
+      consola.success(`Appended Aster MCP config to ${existingPath}`);
+      return { found: true, path: existingPath, action: 'found', snippet };
+    }
+
+    consola.info(`Hermes config found at: ${existingPath}`);
+    consola.info('Add the following to your mcp_servers section:');
+    console.log(snippet);
+    return { found: true, path: existingPath, action: 'found', snippet };
+  }
+
+  // No existing Hermes config — print instructions
+  consola.info('No Hermes config.yaml found in standard locations.');
+  consola.info('Create ~/.hermes/config.yaml with:');
+  console.log(snippet);
+  return { found: false, path: null, action: 'not_found', snippet };
+}
+
+/**
+ * CLI handler for 'aster configure-hermes'
+ */
+export async function runConfigureHermes(): Promise<void> {
+  consola.box({
+    title: 'Aster ↔ Hermes Agent',
+    message: 'Configure Aster as an MCP server for Hermes Agent',
+  });
+
+  const result = configureHermes({ write: false });
+
+  if (result.action === 'found') {
+    consola.success(`\n✅ Hermes config located at: ${result.path}`);
+    consola.info('After adding the snippet, restart Hermes and run:');
+    consola.info('  hermes mcp list   # verify aster tools appear');
+  } else {
+    consola.info('\n📝 Save the config above, then run:');
+    consola.info('  hermes chat       # start chatting — Aster tools are now available');
+  }
+
+  consola.info('\n💡 Example Hermes prompts with Aster:');
+  consola.info('  • "Take a screenshot of my phone and describe what you see"');
+  consola.info('  • "Read my latest SMS messages"');
+  consola.info('  • "Open YouTube and search for cooking videos"');
+  consola.info('  • "Find photos from last week"');
+  consola.info('  • "Get my phone\'s battery status and WiFi info"');
+  consola.info('  • "Add a calendar event: dentist tomorrow at 10am"');
+}

--- a/mcp/src/mcp/handler.ts
+++ b/mcp/src/mcp/handler.ts
@@ -7,6 +7,7 @@ import {
 } from '../websocket/index.js';
 import { parseNaturalLanguageQuery } from '../util/queryParser.js';
 import {
+  AddCalendarEventSchema,
   AnalyzeStorageSchema,
   ClickByIdSchema,
   ClickByTextSchema,
@@ -14,20 +15,27 @@ import {
   DeleteFileSchema,
   DeleteAlarmSchema,
   DismissAlarmSchema,
+  DownloadFileSchema,
   ExecuteShellSchema,
   FindElementSchema,
   FindLargeFilesSchema,
   GetAlarmsSchema,
   GetBatterySchema,
+  GetBluetoothStatusSchema,
+  GetBrightnessSchema,
+  GetCalendarEventsSchema,
   GetClipboardSchema,
   GetDeviceInfoSchema,
   GetLocationSchema,
   GetScreenHierarchySchema,
+  GetStorageSummarySchema,
   GetVolumeSchema,
+  GetWifiInfoSchema,
   GlobalActionSchema,
   IndexMediaMetadataSchema,
   InputGestureSchema,
   InputTextSchema,
+  IsScreenOnSchema,
   LaunchIntentSchema,
   ListContactsFullSchema,
   ListFilesSchema,
@@ -35,6 +43,7 @@ import {
   ListPackagesSchema,
   MakeCallSchema,
   MakeCallWithVoiceSchema,
+  OpenUrlSchema,
   PlayAudioSchema,
   PostNotificationSchema,
   ReadFileSchema,
@@ -45,6 +54,7 @@ import {
   SearchMediaSchema,
   SendSmsSchema,
   SetAlarmSchema,
+  SetBrightnessSchema,
   SetClipboardSchema,
   SetVolumeSchema,
   ShowOverlaySchema,
@@ -53,7 +63,11 @@ import {
   StopAudioSchema,
   TakePhotoSchema,
   TakeScreenshotSchema,
+  ToggleBluetoothSchema,
+  ToggleWifiSchema,
+  UninstallPackageSchema,
   VibrateSchema,
+  WakeScreenSchema,
   WriteFileSchema,
 } from './tools.js';
 
@@ -244,6 +258,50 @@ export async function handleToolCall(
       case 'aster_record_video':
         return handleRecordVideo(args);
 
+      // ─── NEW TOOL HANDLERS ─────────────────────────────────────────────────
+
+      case 'aster_get_wifi_info':
+        return handleGetWifiInfo(args);
+
+      case 'aster_get_bluetooth_status':
+        return handleGetBluetoothStatus(args);
+
+      case 'aster_toggle_wifi':
+        return handleToggleWifi(args);
+
+      case 'aster_toggle_bluetooth':
+        return handleToggleBluetooth(args);
+
+      case 'aster_get_brightness':
+        return handleGetBrightness(args);
+
+      case 'aster_set_brightness':
+        return handleSetBrightness(args);
+
+      case 'aster_open_url':
+        return handleOpenUrl(args);
+
+      case 'aster_get_calendar_events':
+        return handleGetCalendarEvents(args);
+
+      case 'aster_add_calendar_event':
+        return handleAddCalendarEvent(args);
+
+      case 'aster_uninstall_package':
+        return handleUninstallPackage(args);
+
+      case 'aster_download_file':
+        return handleDownloadFile(args);
+
+      case 'aster_is_screen_on':
+        return handleIsScreenOn(args);
+
+      case 'aster_wake_screen':
+        return handleWakeScreen(args);
+
+      case 'aster_get_storage_summary':
+        return handleGetStorageSummary(args);
+
       default:
         return errorResult(`Unknown tool: ${name}`);
     }
@@ -253,7 +311,7 @@ export async function handleToolCall(
   }
 }
 
-// Tool handlers
+// ─── EXISTING TOOL HANDLERS ───────────────────────────────────────────────────
 
 function handleListDevices(): ToolResult {
   const devices = getAllDevices();
@@ -364,7 +422,6 @@ async function handleTakeScreenshot(args: Record<string, unknown>): Promise<Tool
   const { deviceId } = TakeScreenshotSchema.parse(args);
   const response = await sendCommand(deviceId, 'take_screenshot');
   const data = response.data as { screenshot?: string; base64?: string; format?: string; mimeType?: string };
-  // Android returns 'screenshot' field, but also support 'base64' for backward compatibility
   const base64Data = data.screenshot || data.base64;
   if (!base64Data) {
     return errorResult('Screenshot data not found in response');
@@ -452,7 +509,7 @@ async function handleMakeCall(args: Record<string, unknown>): Promise<ToolResult
 
 async function handleMakeCallWithVoice(args: Record<string, unknown>): Promise<ToolResult> {
   const { deviceId, number, text, waitSeconds } = MakeCallWithVoiceSchema.parse(args);
-  const timeout = ((waitSeconds || 8) + 2 + 60) * 1000; // 2s dialer + wait + 60s for TTS and overhead
+  const timeout = ((waitSeconds || 8) + 2 + 60) * 1000;
   const response = await sendCommand(deviceId, 'make_call_with_voice', { number, text, waitSeconds }, timeout);
   return jsonResult(response.data);
 }
@@ -477,7 +534,6 @@ async function handleShowToast(args: Record<string, unknown>): Promise<ToolResul
 
 async function handleLaunchIntent(args: Record<string, unknown>): Promise<ToolResult> {
   const { deviceId, packageName, action, data } = LaunchIntentSchema.parse(args);
-  // Android expects 'package' parameter, not 'packageName'
   const response = await sendCommand(deviceId, 'launch_intent', { package: packageName, action, data });
   return jsonResult(response.data);
 }
@@ -507,7 +563,7 @@ async function handleAnalyzeStorage(args: Record<string, unknown>): Promise<Tool
     maxDepth,
     minSizeMB,
     includeHidden,
-  }, 120000); // 2 minute timeout for large storage analysis
+  }, 120000);
   return jsonResult(response.data);
 }
 
@@ -518,7 +574,7 @@ async function handleFindLargeFiles(args: Record<string, unknown>): Promise<Tool
     path,
     fileTypes,
     limit,
-  }, 60000); // 1 minute timeout
+  }, 60000);
   return jsonResult(response.data);
 }
 
@@ -529,14 +585,13 @@ async function handleIndexMediaMetadata(args: Record<string, unknown>): Promise<
     includeLocation,
     includeExif,
     limit,
-  }, 120000); // 2 minute timeout for large media collections
+  }, 120000);
   return jsonResult(response.data);
 }
 
 async function handleSearchMedia(args: Record<string, unknown>): Promise<ToolResult> {
   const { deviceId, path, dateFrom, dateTo, location, fileTypes, minSizeMB, maxSizeMB, cameraModel, sortBy, limit, query } = SearchMediaSchema.parse(args);
 
-  // If natural language query is provided, parse it
   let searchParams: Record<string, unknown> = {
     path,
     dateFrom,
@@ -552,15 +607,13 @@ async function handleSearchMedia(args: Record<string, unknown>): Promise<ToolRes
 
   if (query) {
     const parsedQuery = parseNaturalLanguageQuery(query);
-
-    // Merge parsed filters with explicit filters (explicit takes precedence)
     if (!dateFrom && parsedQuery.dateFrom) searchParams.dateFrom = parsedQuery.dateFrom;
     if (!dateTo && parsedQuery.dateTo) searchParams.dateTo = parsedQuery.dateTo;
     if (!location && parsedQuery.location) searchParams.location = parsedQuery.location;
     if (!fileTypes && parsedQuery.fileTypes) searchParams.fileTypes = parsedQuery.fileTypes;
   }
 
-  const response = await sendCommand(deviceId, 'search_media', searchParams, 120000); // 2 minute timeout
+  const response = await sendCommand(deviceId, 'search_media', searchParams, 120000);
   return jsonResult(response.data);
 }
 
@@ -638,5 +691,98 @@ async function handleRecordVideo(args: Record<string, unknown>): Promise<ToolRes
   const { deviceId, camera, maxDuration } = RecordVideoSchema.parse(args);
   const timeout = ((maxDuration || 8) + 12) * 1000;
   const response = await sendCommand(deviceId, 'record_video', { camera, maxDuration }, timeout);
+  return jsonResult(response.data);
+}
+
+// ─── NEW TOOL HANDLERS ────────────────────────────────────────────────────────
+
+async function handleGetWifiInfo(args: Record<string, unknown>): Promise<ToolResult> {
+  const { deviceId } = GetWifiInfoSchema.parse(args);
+  const response = await sendCommand(deviceId, 'get_wifi_info');
+  return jsonResult(response.data);
+}
+
+async function handleGetBluetoothStatus(args: Record<string, unknown>): Promise<ToolResult> {
+  const { deviceId } = GetBluetoothStatusSchema.parse(args);
+  const response = await sendCommand(deviceId, 'get_bluetooth_status');
+  return jsonResult(response.data);
+}
+
+async function handleToggleWifi(args: Record<string, unknown>): Promise<ToolResult> {
+  const { deviceId, enable } = ToggleWifiSchema.parse(args);
+  const response = await sendCommand(deviceId, 'toggle_wifi', { enable });
+  return jsonResult(response.data);
+}
+
+async function handleToggleBluetooth(args: Record<string, unknown>): Promise<ToolResult> {
+  const { deviceId, enable } = ToggleBluetoothSchema.parse(args);
+  const response = await sendCommand(deviceId, 'toggle_bluetooth', { enable });
+  return jsonResult(response.data);
+}
+
+async function handleGetBrightness(args: Record<string, unknown>): Promise<ToolResult> {
+  const { deviceId } = GetBrightnessSchema.parse(args);
+  const response = await sendCommand(deviceId, 'get_brightness');
+  return jsonResult(response.data);
+}
+
+async function handleSetBrightness(args: Record<string, unknown>): Promise<ToolResult> {
+  const { deviceId, level, automatic } = SetBrightnessSchema.parse(args);
+  const response = await sendCommand(deviceId, 'set_brightness', { level, automatic });
+  return jsonResult(response.data);
+}
+
+async function handleOpenUrl(args: Record<string, unknown>): Promise<ToolResult> {
+  const { deviceId, url } = OpenUrlSchema.parse(args);
+  const response = await sendCommand(deviceId, 'open_url', { url });
+  return jsonResult(response.data);
+}
+
+async function handleGetCalendarEvents(args: Record<string, unknown>): Promise<ToolResult> {
+  const { deviceId, dateFrom, dateTo, limit } = GetCalendarEventsSchema.parse(args);
+  const response = await sendCommand(deviceId, 'get_calendar_events', { dateFrom, dateTo, limit });
+  return jsonResult(response.data);
+}
+
+async function handleAddCalendarEvent(args: Record<string, unknown>): Promise<ToolResult> {
+  const { deviceId, title, startTime, endTime, description, location, allDay } = AddCalendarEventSchema.parse(args);
+  const response = await sendCommand(deviceId, 'add_calendar_event', {
+    title,
+    startTime,
+    endTime,
+    description,
+    location,
+    allDay,
+  });
+  return jsonResult(response.data);
+}
+
+async function handleUninstallPackage(args: Record<string, unknown>): Promise<ToolResult> {
+  const { deviceId, packageName } = UninstallPackageSchema.parse(args);
+  const response = await sendCommand(deviceId, 'uninstall_package', { packageName });
+  return jsonResult(response.data);
+}
+
+async function handleDownloadFile(args: Record<string, unknown>): Promise<ToolResult> {
+  const { deviceId, url, destinationPath } = DownloadFileSchema.parse(args);
+  const response = await sendCommand(deviceId, 'download_file', { url, destinationPath }, 120000);
+  return jsonResult(response.data);
+}
+
+async function handleIsScreenOn(args: Record<string, unknown>): Promise<ToolResult> {
+  const { deviceId } = IsScreenOnSchema.parse(args);
+  const response = await sendCommand(deviceId, 'is_screen_on');
+  return jsonResult(response.data);
+}
+
+async function handleWakeScreen(args: Record<string, unknown>): Promise<ToolResult> {
+  const { deviceId, durationSec } = WakeScreenSchema.parse(args);
+  const response = await sendCommand(deviceId, 'wake_screen', { durationSec });
+  return jsonResult(response.data);
+}
+
+async function handleGetStorageSummary(args: Record<string, unknown>): Promise<ToolResult> {
+  const { deviceId } = GetStorageSummarySchema.parse(args);
+  const response = await sendCommand(deviceId, 'get_storage_summary');
   return jsonResult(response.data);
 }

--- a/mcp/src/mcp/tools.ts
+++ b/mcp/src/mcp/tools.ts
@@ -297,7 +297,84 @@ export const RecordVideoSchema = z.object({
   maxDuration: z.number().optional().default(8).describe('Maximum recording duration in seconds, 1-8 (default: 8)'),
 });
 
-// Tool definitions for MCP
+// ─── NEW TOOLS ────────────────────────────────────────────────────────────────
+
+export const GetWifiInfoSchema = z.object({
+  deviceId: z.string().describe('The unique identifier of the device'),
+});
+
+export const GetBluetoothStatusSchema = z.object({
+  deviceId: z.string().describe('The unique identifier of the device'),
+});
+
+export const ToggleWifiSchema = z.object({
+  deviceId: z.string().describe('The unique identifier of the device'),
+  enable: z.boolean().describe('Enable or disable WiFi'),
+});
+
+export const ToggleBluetoothSchema = z.object({
+  deviceId: z.string().describe('The unique identifier of the device'),
+  enable: z.boolean().describe('Enable or disable Bluetooth'),
+});
+
+export const GetBrightnessSchema = z.object({
+  deviceId: z.string().describe('The unique identifier of the device'),
+});
+
+export const SetBrightnessSchema = z.object({
+  deviceId: z.string().describe('The unique identifier of the device'),
+  level: z.number().min(0).max(255).describe('Brightness level (0-255)'),
+  automatic: z.boolean().optional().describe('Enable (true) or disable (false) automatic brightness'),
+});
+
+export const OpenUrlSchema = z.object({
+  deviceId: z.string().describe('The unique identifier of the device'),
+  url: z.string().describe('URL to open in the default browser'),
+});
+
+export const GetCalendarEventsSchema = z.object({
+  deviceId: z.string().describe('The unique identifier of the device'),
+  dateFrom: z.string().optional().describe('Start date in ISO format (YYYY-MM-DD). Defaults to today.'),
+  dateTo: z.string().optional().describe('End date in ISO format (YYYY-MM-DD). Defaults to 30 days from dateFrom.'),
+  limit: z.number().optional().default(50).describe('Maximum number of events to return'),
+});
+
+export const AddCalendarEventSchema = z.object({
+  deviceId: z.string().describe('The unique identifier of the device'),
+  title: z.string().describe('Event title'),
+  startTime: z.string().describe('Start time in ISO format (YYYY-MM-DDTHH:MM:SS)'),
+  endTime: z.string().optional().describe('End time in ISO format. Defaults to startTime + 1 hour.'),
+  description: z.string().optional().describe('Event description'),
+  location: z.string().optional().describe('Event location'),
+  allDay: z.boolean().optional().default(false).describe('Whether the event is all-day'),
+});
+
+export const UninstallPackageSchema = z.object({
+  deviceId: z.string().describe('The unique identifier of the device'),
+  packageName: z.string().describe('Package name to uninstall'),
+});
+
+export const DownloadFileSchema = z.object({
+  deviceId: z.string().describe('The unique identifier of the device'),
+  url: z.string().describe('URL to download from'),
+  destinationPath: z.string().optional().describe('Destination path on device. Defaults to /sdcard/Download/<filename>.'),
+});
+
+export const IsScreenOnSchema = z.object({
+  deviceId: z.string().describe('The unique identifier of the device'),
+});
+
+export const WakeScreenSchema = z.object({
+  deviceId: z.string().describe('The unique identifier of the device'),
+  durationSec: z.number().optional().default(5).describe('How long to keep the screen on (seconds, 1-60)'),
+});
+
+export const GetStorageSummarySchema = z.object({
+  deviceId: z.string().describe('The unique identifier of the device'),
+});
+
+// ─── TOOL DEFINITIONS ─────────────────────────────────────────────────────────
+
 export const TOOL_DEFINITIONS = [
   {
     name: 'aster_list_devices',
@@ -968,6 +1045,181 @@ export const TOOL_DEFINITIONS = [
         deviceId: { type: 'string', description: 'The unique identifier of the device' },
         camera: { type: 'string', enum: ['front', 'back'], description: 'Camera to use (default: back)', default: 'back' },
         maxDuration: { type: 'number', description: 'Max recording duration 1-8 seconds (default: 8)', default: 8 },
+      },
+      required: ['deviceId'],
+    },
+  },
+
+  // ─── NEW TOOL DEFINITIONS ──────────────────────────────────────────────────
+
+  {
+    name: 'aster_get_wifi_info',
+    description: 'Get WiFi connection details: SSID, BSSID, IP address, signal strength (RSSI), link speed, and frequency band. Returns null fields if WiFi is disconnected.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        deviceId: { type: 'string', description: 'The unique identifier of the device' },
+      },
+      required: ['deviceId'],
+    },
+  },
+  {
+    name: 'aster_get_bluetooth_status',
+    description: 'Get Bluetooth adapter state (ON/OFF/TURNING_ON/TURNING_OFF), paired device count, and list of paired device names/addresses.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        deviceId: { type: 'string', description: 'The unique identifier of the device' },
+      },
+      required: ['deviceId'],
+    },
+  },
+  {
+    name: 'aster_toggle_wifi',
+    description: 'Enable or disable WiFi on the device. Requires the companion app to hold the CHANGE_WIFI_STATE permission (granted via ADB or root on Android 10+).',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        deviceId: { type: 'string', description: 'The unique identifier of the device' },
+        enable: { type: 'boolean', description: 'Enable or disable WiFi' },
+      },
+      required: ['deviceId', 'enable'],
+    },
+  },
+  {
+    name: 'aster_toggle_bluetooth',
+    description: 'Enable or disable Bluetooth on the device. Requires BLUETOOTH_ADMIN permission.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        deviceId: { type: 'string', description: 'The unique identifier of the device' },
+        enable: { type: 'boolean', description: 'Enable or disable Bluetooth' },
+      },
+      required: ['deviceId', 'enable'],
+    },
+  },
+  {
+    name: 'aster_get_brightness',
+    description: 'Get the current screen brightness level (0-255) and whether automatic brightness is enabled.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        deviceId: { type: 'string', description: 'The unique identifier of the device' },
+      },
+      required: ['deviceId'],
+    },
+  },
+  {
+    name: 'aster_set_brightness',
+    description: 'Set the screen brightness level (0-255) and optionally toggle automatic brightness mode. Requires WRITE_SETTINGS permission (granted via ADB or the Settings app).',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        deviceId: { type: 'string', description: 'The unique identifier of the device' },
+        level: { type: 'number', description: 'Brightness level 0-255' },
+        automatic: { type: 'boolean', description: 'Enable (true) or disable (false) automatic brightness' },
+      },
+      required: ['deviceId', 'level'],
+    },
+  },
+  {
+    name: 'aster_open_url',
+    description: 'Open a URL in the default web browser on the device. Useful for showing web pages, starting downloads, or deep-linking into apps.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        deviceId: { type: 'string', description: 'The unique identifier of the device' },
+        url: { type: 'string', description: 'URL to open (https://, http://, intent://, market://, etc.)' },
+      },
+      required: ['deviceId', 'url'],
+    },
+  },
+  {
+    name: 'aster_get_calendar_events',
+    description: 'Fetch calendar events from the device within a date range. Returns title, start/end time, location, description, and whether all-day. Requires READ_CALENDAR permission.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        deviceId: { type: 'string', description: 'The unique identifier of the device' },
+        dateFrom: { type: 'string', description: 'Start date ISO format (YYYY-MM-DD). Defaults to today.' },
+        dateTo: { type: 'string', description: 'End date ISO format (YYYY-MM-DD). Defaults to 30 days from dateFrom.' },
+        limit: { type: 'number', description: 'Maximum events to return', default: 50 },
+      },
+      required: ['deviceId'],
+    },
+  },
+  {
+    name: 'aster_add_calendar_event',
+    description: 'Add a new event to the device calendar. Requires WRITE_CALENDAR permission. Uses the default calendar.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        deviceId: { type: 'string', description: 'The unique identifier of the device' },
+        title: { type: 'string', description: 'Event title' },
+        startTime: { type: 'string', description: 'Start time ISO format (YYYY-MM-DDTHH:MM:SS)' },
+        endTime: { type: 'string', description: 'End time ISO format; defaults to startTime + 1 hour' },
+        description: { type: 'string', description: 'Event description' },
+        location: { type: 'string', description: 'Event location' },
+        allDay: { type: 'boolean', description: 'All-day event', default: false },
+      },
+      required: ['deviceId', 'title', 'startTime'],
+    },
+  },
+  {
+    name: 'aster_uninstall_package',
+    description: 'Uninstall an app by its package name. Opens the system uninstall dialog; the user may need to confirm. Cannot uninstall system apps.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        deviceId: { type: 'string', description: 'The unique identifier of the device' },
+        packageName: { type: 'string', description: 'Package name to uninstall (e.g., "com.example.app")' },
+      },
+      required: ['deviceId', 'packageName'],
+    },
+  },
+  {
+    name: 'aster_download_file',
+    description: 'Download a file from a URL to the device. Saves to /sdcard/Download/ by default. Reports progress and final path. Requires INTERNET permission.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        deviceId: { type: 'string', description: 'The unique identifier of the device' },
+        url: { type: 'string', description: 'URL to download from' },
+        destinationPath: { type: 'string', description: 'Destination path; defaults to /sdcard/Download/<filename>' },
+      },
+      required: ['deviceId', 'url'],
+    },
+  },
+  {
+    name: 'aster_is_screen_on',
+    description: 'Check whether the device screen is currently on (awake) or off. Returns a boolean and the current display state.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        deviceId: { type: 'string', description: 'The unique identifier of the device' },
+      },
+      required: ['deviceId'],
+    },
+  },
+  {
+    name: 'aster_wake_screen',
+    description: 'Wake the device screen (turn it on) and keep it awake for a specified duration. Uses a wake lock that is automatically released. Useful before performing UI automation on a sleeping device.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        deviceId: { type: 'string', description: 'The unique identifier of the device' },
+        durationSec: { type: 'number', description: 'Keep screen on for this many seconds (1-60)', default: 5 },
+      },
+      required: ['deviceId'],
+    },
+  },
+  {
+    name: 'aster_get_storage_summary',
+    description: 'Get a quick storage overview: total space, used space, free space (in bytes and human-readable), and usage percentage. Much faster than analyze_storage for a quick check.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        deviceId: { type: 'string', description: 'The unique identifier of the device' },
       },
       required: ['deviceId'],
     },


### PR DESCRIPTION
## **User description**
## מה חדש / What's New

### 🔧 14 כלים חדשים ל-MCP

כלים שלא היו קיימים — כל אחד עוקב אחר אותו דפוס Zod schema + handler + TOOL_DEFINITIONS:

| Tool | תיאור |
|------|-------|
| `aster_get_wifi_info` | WiFi SSID, BSSID, IP, RSSI, link speed, frequency |
| `aster_get_bluetooth_status` | מצב Bluetooth + רשימת מכשירים מצומדים |
| `aster_toggle_wifi` | הפעל/כבה WiFi |
| `aster_toggle_bluetooth` | הפעל/כבה Bluetooth |
| `aster_get_brightness` | רמת בהירות נוכחית (0-255) + מצב אוטומטי |
| `aster_set_brightness` | קבע בהירות + toggle למצב אוטומטי |
| `aster_open_url` | פתח URL בדפדפן ברירת המחדל |
| `aster_get_calendar_events` | אירועי יומן לפי טווח תאריכים |
| `aster_add_calendar_event` | צור אירוע יומן חדש |
| `aster_uninstall_package` | הסר אפליקציה לפי package name |
| `aster_download_file` | הורד קובץ מ-URL למכשיר |
| `aster_is_screen_on` | בדוק אם המסך דולק |
| `aster_wake_screen` | הער מסך + השאר דולק ל-N שניות |
| `aster_get_storage_summary` | סיכום אחסון מהיר (total/used/free) |

### 🔗 אינטגרציה עם Hermes Agent

- **מודול `src/hermes/`** — מחולל config ל-Hermes Agent
- **`aster configure-hermes`** — פקודת CLI חדשה שמזהה אוטומטית את קובץ ה-config של Hermes ומדפיסה את ה-snippet הנכון
- **`HERMES_INTEGRATION.md`** — מדריך מלא: התקנה, דוגמאות prompts, אבטחה, troubleshooting
- תמיכה ב-Tailscale לחיבור מרחוק

### 📦 קבצים ששונו

```
mcp/bin/aster.ts          ← נוספה פקודת configure-hermes
mcp/src/mcp/tools.ts      ← 14 Schemas חדשים + הרחבת TOOL_DEFINITIONS
mcp/src/mcp/handler.ts    ← 14 handlers חדשים + מיפוי ב-switch
mcp/src/hermes/index.ts   ← [חדש] מחולל Hermes config
mcp/src/hermes/__tests__/index.test.ts ← [חדש] טסטים
HERMES_INTEGRATION.md     ← [חדש] מדריך אינטגרציה
```

### ⚠️ שים לב

הצד של **האפליקציה האנדרואידית** צריך handlers מתאימים לפקודות ה-WebSocket החדשות:
`get_wifi_info`, `get_bluetooth_status`, `toggle_wifi`, `toggle_bluetooth`, `get_brightness`, `set_brightness`, `open_url`, `get_calendar_events`, `add_calendar_event`, `uninstall_package`, `download_file`, `is_screen_on`, `wake_screen`, `get_storage_summary`

ה-MCP server ישלח פקודות אלו — אבל בלי מימוש בצד האנדרואיד, הן יחזירו `unknown command`.


___

## **CodeAnt-AI Description**
**Add Hermes Agent setup and new device control tools**

### What Changed
- Added a `configure-hermes` command that shows how to connect Aster to Hermes Agent, with support for custom host, port, and optional auto-append to an existing Hermes config.
- Added documentation for setting up Hermes with Aster, including local and remote setup examples and tool filtering guidance.
- Added new device tools for WiFi, Bluetooth, screen brightness, calendar events, URL opening, app uninstalling, file downloading, screen status, waking the screen, and storage summary.
- Added tests for the Hermes config snippet to confirm the setup instructions include the expected server details.

### Impact
`✅ Faster Hermes setup`
`✅ Easier access to phone settings and actions from Hermes`
`✅ Clearer setup instructions for local and remote use`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
